### PR TITLE
feat: refine home screen and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The app will be available at your Vercel URL with the following pages:
 - `/` - Landing page
 - `/signup` - Sign up form
 - `/login` - Login form
+- `/home` - Recipe generator and past recipes
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest",
+    "test:ci": "vitest run"
   },
   "dependencies": {
     "bcryptjs": "^3.0.2",
@@ -25,6 +27,9 @@
     "eslint-config-next": "15.0.0",
     "postcss": "^8.0.0",
     "tailwindcss": "^3.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@testing-library/jest-dom": "^6.1.2",
+    "@testing-library/react": "^14.2.1",
+    "vitest": "^1.0.0"
   }
 }

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import React from 'react'
+import RecipeList from '@/components/RecipeList'
+import { useRecipes } from '@/lib/recipes'
+
+export default function HomeScreen() {
+  const { addRecipe } = useRecipes()
+
+  const handleGenerate = () => {
+    // For now just add a placeholder recipe
+    const name = `Recipe ${Math.floor(Math.random() * 1000)}`
+    addRecipe(name)
+  }
+
+  return (
+    <div className="min-h-screen px-4 py-8 bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
+      <div className="max-w-xl mx-auto space-y-6">
+        <button
+          onClick={handleGenerate}
+          className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-3 px-4 rounded-lg transition duration-200"
+        >
+          Generate New Recipe
+        </button>
+        <RecipeList />
+      </div>
+    </div>
+  )
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -51,8 +51,8 @@ export default function LoginPage() {
       if (result?.error) {
         setErrors({ form: 'Invalid email or password' })
       } else {
-        // Redirect to home page on successful login
-        router.push('/')
+        // Redirect to home screen on successful login
+        router.push('/home')
         router.refresh()
       }
     } catch (error) {
@@ -147,4 +147,4 @@ export default function LoginPage() {
       </div>
     </div>
   )
-} 
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,4 +36,4 @@ export default function HomePage() {
       </div>
     </div>
   )
-} 
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -2,7 +2,12 @@
 
 import React from 'react'
 import { SessionProvider } from 'next-auth/react'
+import { RecipesProvider } from '@/lib/recipes'
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  return <SessionProvider>{children}</SessionProvider>
-} 
+  return (
+    <SessionProvider>
+      <RecipesProvider>{children}</RecipesProvider>
+    </SessionProvider>
+  )
+}

--- a/src/components/RecipeList.test.tsx
+++ b/src/components/RecipeList.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import React from 'react'
+import RecipeList from './RecipeList'
+import { RecipesProvider } from '@/lib/recipes'
+
+describe('RecipeList', () => {
+  it('renders recipe items', () => {
+    const wrapper = (
+      <RecipesProvider>
+        <RecipeList />
+      </RecipesProvider>
+    )
+
+    render(wrapper)
+
+    // Initially no recipes
+    expect(screen.getByText(/no recipes yet/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/RecipeList.tsx
+++ b/src/components/RecipeList.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import React from 'react'
+import { useRecipes } from '@/lib/recipes'
+
+export default function RecipeList() {
+  const { recipes } = useRecipes()
+
+  if (recipes.length === 0) {
+    return <p className="text-gray-600">No recipes yet. Generate one to get started.</p>
+  }
+
+  return (
+    <ul className="space-y-4">
+      {recipes.map(recipe => (
+        <li key={recipe.id} className="border rounded-lg p-4 shadow-sm">
+          <h3 className="font-semibold text-lg">{recipe.name}</h3>
+          <p className="text-sm text-gray-500">{new Date(recipe.date).toLocaleDateString()}</p>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/lib/recipes.tsx
+++ b/src/lib/recipes.tsx
@@ -1,0 +1,41 @@
+import React, { createContext, useContext, useState } from 'react'
+
+export type Recipe = {
+  id: string
+  name: string
+  date: string
+}
+
+interface RecipesContextValue {
+  recipes: Recipe[]
+  addRecipe: (name: string) => void
+}
+
+const RecipesContext = createContext<RecipesContextValue | undefined>(undefined)
+
+export function RecipesProvider({ children }: { children: React.ReactNode }) {
+  const [recipes, setRecipes] = useState<Recipe[]>([])
+
+  const addRecipe = (name: string) => {
+    setRecipes(prev => [
+      ...prev,
+      {
+        id: crypto.randomUUID(),
+        name,
+        date: new Date().toISOString()
+      }
+    ])
+  }
+
+  return (
+    <RecipesContext.Provider value={{ recipes, addRecipe }}>
+      {children}
+    </RecipesContext.Provider>
+  )
+}
+
+export function useRecipes() {
+  const context = useContext(RecipesContext)
+  if (!context) throw new Error('useRecipes must be used within RecipesProvider')
+  return context
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: './vitest.setup.ts'
+  }
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary
- home screen shows recipe feed and generator
- store recipes in context with unique IDs
- document new `/home` page in README

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm type-check` *(fails: dependencies missing)*
- `pnpm test:ci` *(fails: vitest not found)*
- `pnpm build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880388eaddc832c97b6ccbd0967a2e7